### PR TITLE
Make logstash package name a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ logstash_baseurl: "https://artifacts.elastic.co"
 logstash_repo_baseurl: "{{logstash_baseurl}}/packages/{{logstash_version}}"
 logstash_package_baseurl: "{{logstash_baseurl}}/downloads/logstash"
 
+# Optionally include version to lock in on a specific version
+logstash_package_name: logstash
+
 # Logstash upgrade
 #  If the package is to be upgraded, (major, minor or patch release),
 #  and there is a currently installed version on the system, you can

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -14,6 +14,6 @@
 - name: Logstash packages (Debian)
   apt:
     state: "{{ (logstash_upgrade) | ternary('latest', 'present') }}"
-    name: "logstash"
+    name: "{{ logstash_package_name }}"
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -10,8 +10,8 @@
 
 - name: Logstash packages (RedHat)
   yum:
-    state: present
-    name: "logstash"
+    state: "{{ (logstash_upgrade) | ternary('latest', 'present') }}"
+    name: "{{ logstash_package_name }}"
     update_cache: yes
 
 # vi:ts=2:sw=2:et:ft=yaml


### PR DESCRIPTION
This change simply adds a variable for the logstash package name, which allows for locking in on a specific version rather than always taking the latest from the repository upon the initial configuration run.

It also adds the upgrade logic that is present in the Debian install task and sets state to `latest` when `logstash_upgrade` is true. If this was left out of the RedHat install for a reason, let me know.